### PR TITLE
Add OpenShift pipeline as code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,61 @@
+/* 
+  assumes build and deployment configurations have been created beforehand as below:
+
+  oc new-build --binary=true --name=spring-demo-bake registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.3 --to=spring-demo
+  oc new-app --image-stream spring-demo --name=spring-demo-dev
+  oc expose dc spring-demo-dev
+  oc set env dc spring-demo-dev JAVA_OPTIONS="-Dmanagement.endpoints.jmx.exposure.include=health,info"
+  oc set probe dc spring-demo-dev --readiness --get-url=http://:8080/health
+  oc set probe dc spring-demo-dev --liveness --get-url=http://:8080/health
+*/
+
+def appName = "spring-demo"
+def imageBuildConfig = appName + "-bake"
+def deploymentConfig = appName + "-dev"
+
+pipeline {
+  agent {
+    label 'maven'
+  }
+  stages {
+    stage('Run unit tests') {
+      steps {
+        echo "Run unit tests"
+        sh 'mvn test'
+      }
+      post {
+        always {
+          junit 'target/surefire-reports/*.xml'
+        }
+      }
+    }
+
+    stage('Build') {
+      steps {
+        echo "Build artifact"
+        sh 'mvn package'
+        echo "Trigger image build"
+        script {
+          openshift.withCluster() {
+            openshift.selector("bc", imageBuildConfig).startBuild("--from-file=target/ROOT.jar", "--wait")
+            }
+          }
+        }
+      post {
+        success {
+          archiveArtifacts artifacts: 'target/**.jar', fingerprint: true
+        }
+      }
+    }
+
+    stage('Deploy') {
+      steps {
+        script {
+          openshift.withCluster() {
+            openshift.selector("dc", deploymentConfig).rollout()
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>gs-spring-boot</artifactId>
     <version>0.1.0</version>
 
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
Adds a basic pipeline as code in a Jenkinsfile with instructions how to set up.

Still todo:
- Create build and deployment configs from template, provisioned by Jenkins
- Add environments and image promotion (dev, test, staging, prod)
